### PR TITLE
2022/3/20  会員関連　管理者側エラー修正

### DIFF
--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,5 +1,7 @@
 class Public::CustomersController < ApplicationController
 
+  before_action :authenticate_admin!
+
   def show
     @customer = current_customer
   end
@@ -10,7 +12,7 @@ class Public::CustomersController < ApplicationController
   end
 
   def update
-    @customer = Customer.find(params[:id])
+    @customer = current_customer
     if @customer.update(customer_params)
       redirect_to customer_path(current_customer), notice: "You have updated user successfully."
     else

--- a/app/views/admin/customers/edit.html.erb
+++ b/app/views/admin/customers/edit.html.erb
@@ -2,19 +2,19 @@
     <h2>登録情報編集</h2>
     <%= form_with model:@customer, local:true do |f| %>
 
-      <%= f.label :"#{@customer.id}" %>
-      <%= f.label :"姓" %>
-      <%= f.text_field :first_name, autofocus: true %>
-      <%= f.label :"名" %>
-      <%= f.text_field :last_name %>
-      <%= f.label :"郵便番号" %>
-      <%= f.text_field :postal_code %>
-      <%= f.label :"住所" %>
-      <%= f.text_field :address %>
-      <%= f.label :"電話番号" %>
-      <%= f.text_field :phone_number %>
-      <%= f.label :"メールアドレス" %>
-      <%= text_field :email %>
+      <p><%= f.label :"会員ID#{@customer.id}" %></p>
+      <p><%= f.label :"姓" %>
+        <%= f.text_field :first_name, autofocus: true %></p>
+      <p><%= f.label :"名" %>
+        <%= f.text_field :last_name %></p>
+      <p><%= f.label :"郵便番号" %>
+        <%= f.text_field :postal_code %></p>
+      <p><%= f.label :"住所" %>
+        <%= f.text_field :address %></p>
+      <p><%= f.label :"電話番号" %>
+        <%= f.text_field :phone_number %></p>
+      <p><%= f.label :"メールアドレス" %>
+        <%= f.text_field :email %></p>
 
       <%= f.label :会員ステータス, class: "ml-3" %>
         <div>

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -13,8 +13,8 @@
       <% @customers.each do |customer| %>
         <tr>
           <td><%= customer.id %></td>
-          <td><%= link_to admin_customer_path do %>
-              <%= customer.fist_name %>&ensp;<%= customer.last_name %>
+          <td><%= link_to admin_customer_path(customer) do %>#(customerを付けるとなぜ治った?
+              <%= customer.first_name %>&ensp;<%= customer.last_name %>
               <% end %>
           </td>
           <td><%= customer.email %></td>

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -1,10 +1,10 @@
-  <h2><%= fist_name(@customer) %>&ensp;<%= last_name(@customer) %>の詳細</h2>
+  <h2><%= @customer.first_name %>の詳細</h2> &ensp;<%#= last_name(@customer) %>#こちらではダメ？
 
 
   <table class="table table-hover">
     <tr class="table-info">
       <th scope="row">氏名</th>
-        <td><%= @customer.fist_name %>&ensp;<%= @customer.last_name %></td>
+        <td><%= @customer.first_name %>&ensp;<%= @customer.last_name %></td>
     </tr>
     <tr class="table-info">
       <th scop="row">カナ</th>
@@ -29,7 +29,7 @@
     <tr class="table-info">
       <th>会員ID・ステータス</th>
         <td><%= @customer.id %>&ensp;
-            <% if customer.is_active == false %>
+            <% if @customer.is_deleted == false %>
               有効
             <% else %>
                 退会済み
@@ -39,6 +39,6 @@
 
 
   <div class="col-sm-3 my-auto">
-    <%= link_to "会員情報を編集する", edit_admin_customer_path, class: "btn btn-primary" %>
+    <%= link_to "会員情報を編集する", edit_admin_customer_path, class: "btn btn-primary" %> #ユーザーのマイページに飛ぶ
     <%= link_to "注文履歴一覧を見る", admin_customer_path, class: "btn btn-primary mt-5" %> #後でパス合わせる
   </div>


### PR DESCRIPTION
管理者側エラーを修正しました。
一覧・詳細・編集ページ見ることが出来ます。

未解決
unsubscribeに移動しない。
管理者側でのサインアップがないため、ログインが出来ない。
→管理者側で会員情報を更新しようとしてもログインを求められるため更新不可。

ログイン関連の実装で解決できるようでしたら、宜しくお願いします。